### PR TITLE
RDKEMW-1144: Crashupload Turn key changes for RDK-E

### DIFF
--- a/uploadDumps.sh
+++ b/uploadDumps.sh
@@ -603,7 +603,6 @@ saveDump()
 
 VERSION_FILE="version.txt"
 boxType=$BOX_TYPE
-
 modNum=`sh $RDK_PATH/getDeviceDetails.sh read model_number`
 
 # Ensure modNum is not empty

--- a/uploadDumps.sh
+++ b/uploadDumps.sh
@@ -603,7 +603,8 @@ saveDump()
 
 VERSION_FILE="version.txt"
 boxType=$BOX_TYPE
-modNum=$(getModel)
+
+modNum=`sh $RDK_PATH/getDeviceDetails.sh read model_number`
 
 # Ensure modNum is not empty
 checkParameter modNum


### PR DESCRIPTION
Reason for change: Crashupload Turn key changes for RDK-E
Test Procedure: Refer JIRA
Risks: Medium
Priority: P1