### PR TITLE
RDKB-61800 [AUTO-SKY][Sprint]Crashes are not uploaded to Stack trace Portal

### DIFF
--- a/uploadDumps.sh
+++ b/uploadDumps.sh
@@ -337,10 +337,9 @@ checkMAC()
             logMessage "Output of ifconfig:"
             ifconfig -a 2>&1 | logStdout
         fi
-    else
-        # forcibly take to UPPER case and remove colons if present
-        MAC=`echo "$MAC" | tr a-f A-F | sed -e 's/://g'`
     fi
+    # forcibly take to UPPER case and remove colons if present
+    MAC=`echo "$MAC" | tr a-f A-F | sed -e 's/://g'`
 }
 
 deleteAllButTheMostRecentFile()


### PR DESCRIPTION
Update uploadDumps.sh to remove the ":" from macaddress